### PR TITLE
CSS: Fix mixed content, add font fallback

### DIFF
--- a/temple-of-rust.css
+++ b/temple-of-rust.css
@@ -5,7 +5,7 @@ body {
     color: white;
     text-align: center;
     font-size: 24pt;
-    font-family: 'Fira Mono';
+    font-family: 'Fira Mono', monospace;
 }
 
 img {

--- a/temple-of-rust.css
+++ b/temple-of-rust.css
@@ -1,4 +1,4 @@
-@import url(http://fonts.googleapis.com/css?family=Fira+Mono:700);
+@import url(https://fonts.googleapis.com/css?family=Fira+Mono:700);
 
 body {
     background-color: black;


### PR DESCRIPTION
In the CSS stylesheet `temple-of-rust.css`, in the rule for the `body`
element, the property `font-family` is specified with only a single
value, `'Fira Mono'`, with no fallback value for use in the event that
the typeface Fira Mono is unavailable; for me, this resulted in the
text being rendered in the typeface Liberation Serif.

In the same stylesheet, an `@import` rule is specified to load the
definition of the typeface Fira Mono from Google Fonts; this rule is
specified such that the resource is to be loaded via unsecured HTTP.

If the `temple-of-rust` Web-page is loaded via HTTPS, this definition
of the `@import` rule may result in mixed-content errors, which may
result in the viewer's Web browser refusing to load the resource, as
it does for me in Chromium 52.

These patches change the `@import` rule to instead load the resource
via HTTPS, and change the `font-family` property to fall back to the
viewer's default monospace typeface in case Fira Mono is still
unavailable.
